### PR TITLE
Updated for diesel v1.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 target
 Cargo.lock
+/.idea
+/*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-authors = ["Georg Semmler <georg_semmler_05@web.de>"]
+authors = [
+    "Georg Semmler <georg_semmler_05@web.de>",
+    "Janosch Gräf <janosch.graef@cispa-helmholtz.de>"
+]
 name = "diesel-custom-type"
-version = "0.1.0"
+version = "1.3.3"
 
 [dependencies]
-diesel = "0.8.2"
+diesel = "1.3.3"


### PR DESCRIPTION
Hi,

I updated this macro for diesel 1.3.3. First I fixed the existing trait implementations and then I implemented Queryable.

But I couldn't figure out why my implementation for Queryable works only when the RawType of the Backend is [u8]. So this won't work with SQLite. Maybe you have an idea?

I only tested inserting and querying a custom type, which is an enum mapped to a VARCHAR. I will test it more though. So maybe you want to wait with the merge.